### PR TITLE
Modified the proxy/proxy factory to take canonical facts and tags

### DIFF
--- a/internal/connection_repository/deserialization.go
+++ b/internal/connection_repository/deserialization.go
@@ -1,0 +1,43 @@
+package connection_repository
+
+import (
+	"database/sql"
+	"encoding/json"
+
+	"github.com/RedHatInsights/cloud-connector/internal/domain"
+
+	"github.com/sirupsen/logrus"
+)
+
+func deserializeDispatchers(log *logrus.Entry, serializedDispatchers sql.NullString) domain.Dispatchers {
+	var dispatchers domain.Dispatchers
+	if serializedDispatchers.Valid {
+		err := json.Unmarshal([]byte(serializedDispatchers.String), &dispatchers)
+		if err != nil {
+			log.WithFields(logrus.Fields{"error": err}).Error("Unable to unmarshal dispatchers from database")
+		}
+	}
+	return dispatchers
+}
+
+func deserializeCanonicalFacts(log *logrus.Entry, serializedCanonicalFacts sql.NullString) domain.CanonicalFacts {
+	var canonicalFacts domain.CanonicalFacts
+	if serializedCanonicalFacts.Valid {
+		err := json.Unmarshal([]byte(serializedCanonicalFacts.String), &canonicalFacts)
+		if err != nil {
+			log.WithFields(logrus.Fields{"error": err}).Error("Unable to unmarshal canonical facts from database")
+		}
+	}
+	return canonicalFacts
+}
+
+func deserializeTags(log *logrus.Entry, serializedTags sql.NullString) domain.Tags {
+	var tags domain.Tags
+	if serializedTags.Valid {
+		err := json.Unmarshal([]byte(serializedTags.String), &tags)
+		if err != nil {
+			log.WithFields(logrus.Fields{"error": err}).Error("Unable to unmarshal tags from database")
+		}
+	}
+	return tags
+}

--- a/internal/connection_repository/permitted_tenant_connection_locator.go
+++ b/internal/connection_repository/permitted_tenant_connection_locator.go
@@ -44,7 +44,7 @@ func (pacl *PermittedTenantConnectionLocator) GetConnection(ctx context.Context,
 		return nil
 	}
 
-	conn, err := pacl.proxyFactory.CreateProxy(ctx, clientState.OrgID, clientState.Account, clientState.ClientID, clientState.Dispatchers)
+	conn, err := pacl.proxyFactory.CreateProxy(ctx, clientState.OrgID, clientState.Account, clientState.ClientID, clientState.CanonicalFacts, clientState.Dispatchers, clientState.Tags)
 	if err != nil {
 		log.WithFields(logrus.Fields{"error": err}).Error("Unable to create the proxy")
 		return nil

--- a/internal/controller/account_resolver.go
+++ b/internal/controller/account_resolver.go
@@ -64,7 +64,7 @@ func (bar *BOPAccountIdResolver) MapClientIdToAccountId(ctx context.Context, cli
 	if err != nil {
 		return "", "", "", err
 	}
-	
+
 	req.Header.Add("accept", "application/json")
 	req.Header.Add("x-rh-certauth-cn", fmt.Sprintf("/CN=%s", clientID))
 	req.Header.Add("x-rh-insights-request-id", requestID)

--- a/internal/controller/api/connection_mediator_v2.go
+++ b/internal/controller/api/connection_mediator_v2.go
@@ -119,7 +119,7 @@ func (this *ConnectionMediatorV2) handleSendMessage() http.HandlerFunc {
 			return
 		}
 
-		client, err := this.proxyFactory.CreateProxy(req.Context(), clientState.OrgID, clientState.Account, clientState.ClientID, clientState.Dispatchers)
+		client, err := this.proxyFactory.CreateProxy(req.Context(), clientState.OrgID, clientState.Account, clientState.ClientID, clientState.CanonicalFacts, clientState.Dispatchers, clientState.Tags)
 		if err != nil {
 			logging.LogWithError(logger, "Unable to create proxy for connection", err)
 			writeConnectionFailureResponse(logger, w)

--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -74,10 +74,10 @@ type connectionID struct {
 }
 
 type connectionStatusResponse struct {
-	Status         string                `json:"status"`
-	Dispatchers    interface{}           `json:"dispatchers,omitempty"`
-	CanonicalFacts domain.CanonicalFacts `json:"canonical_facts,omitempty"`
-	Tags           domain.Tags           `json:"tags,omitempty"`
+	Status         string      `json:"status"`
+	Dispatchers    interface{} `json:"dispatchers,omitempty"`
+	CanonicalFacts interface{} `json:"canonical_facts,omitempty"`
+	Tags           interface{} `json:"tags,omitempty"`
 }
 
 type connectionPingResponse struct {

--- a/internal/controller/types.go
+++ b/internal/controller/types.go
@@ -25,5 +25,5 @@ type ConnectorClient interface {
 }
 
 type ConnectorClientProxyFactory interface {
-	CreateProxy(context.Context, domain.OrgID, domain.AccountID, domain.ClientID, domain.Dispatchers) (ConnectorClient, error)
+	CreateProxy(context.Context, domain.OrgID, domain.AccountID, domain.ClientID, domain.CanonicalFacts, domain.Dispatchers, domain.Tags) (ConnectorClient, error)
 }

--- a/internal/mqtt/connector_client_proxy_factory.go
+++ b/internal/mqtt/connector_client_proxy_factory.go
@@ -23,19 +23,21 @@ func NewConnectorClientMQTTProxyFactory(cfg *config.Config, mqttClient MQTT.Clie
 	return &proxyFactory, nil
 }
 
-func (ccpf *ConnectorClientMQTTProxyFactory) CreateProxy(ctx context.Context, orgID domain.OrgID, account domain.AccountID, client_id domain.ClientID, dispatchers domain.Dispatchers) (controller.ConnectorClient, error) {
+func (ccpf *ConnectorClientMQTTProxyFactory) CreateProxy(ctx context.Context, orgID domain.OrgID, account domain.AccountID, client_id domain.ClientID, canonicalFacts domain.CanonicalFacts, dispatchers domain.Dispatchers, tags domain.Tags) (controller.ConnectorClient, error) {
 
 	logger := logger.Log.WithFields(logrus.Fields{"org_id": orgID, "account": account, "client_id": client_id})
 
 	proxy := ConnectorClientMQTTProxy{
-		Logger:       logger,
-		Config:       ccpf.config,
-		OrgID:        orgID,
-		AccountID:    account,
-		ClientID:     client_id,
-		Client:       ccpf.mqttClient,
-		TopicBuilder: ccpf.topicBuilder,
-		Dispatchers:  dispatchers,
+		Logger:         logger,
+		Config:         ccpf.config,
+		OrgID:          orgID,
+		AccountID:      account,
+		ClientID:       client_id,
+		Client:         ccpf.mqttClient,
+		TopicBuilder:   ccpf.topicBuilder,
+		CanonicalFacts: canonicalFacts,
+		Dispatchers:    dispatchers,
+		Tags:           tags,
 	}
 
 	return &proxy, nil


### PR DESCRIPTION
The "add canonical facts" task was more difficult than I thought.  I forgot I was not retrieving the canonical facts and tags from the database and passing them to the proxy.  This change should fix that issue.

With the v1 code, I jammed the proxy factory into the connection_repository code.  I now think this was a mistake.  I took a slightly different approach with the v2 bits of the code.  With the v2 code, I am modifying the GetConnection() logic so that it just retrieves the connection state (all of it...hopefully) from the database.  You can then pass that connection state to a proxy factory to build a proxy instance if you need to or you can convert the connection state (serialize) to a json doc and return it from the rest api.  I think the v2 approach is cleaner and more flexible.

I kinda through this patch together so take a look and let me know what you think.

We can hop on a call and walk through it if you like.